### PR TITLE
herdr向けのカスタマイズ設定を追加する

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,19 @@
+onboarding = false
+# herdr configuration
+# https://herdr.dev/docs/configuration/
+
+[keys]
+# screenの escape (ctrl+z) に合わせる
+prefix = "ctrl+z"
+
+# screenのペイン分割/統合の感覚に合わせる (C-a |, C-a S, C-a Q)
+# 左右分割 (screen: C-a |)
+split_vertical = "prefix+|"
+# 上下分割 (screen: C-a S)
+split_horizontal = "prefix+shift+s"
+# 統合 (screen: C-a Q "only" 相当の完全一致機能はherdrに無いためzoomで代用。
+# デフォルトのprefix+zも残す)
+zoom = ["prefix+z", "prefix+shift+q"]
+
+[experimental]
+pane_history = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .zshrc_ex
+
+# herdr runtime files (regenerated on each run)
+.config/herdr/session.json
+.config/herdr/*.log
+.config/herdr/*.sock

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,26 @@ do
 	    name=$(basename "$config_item")
 	    target="$HOME/.config/$name"
 
+	    # ---- herdr: ソケットをUnixドメインソケット非対応のファイルシステム
+	    # (WSL2のDrvFsマウント配下等)に作らせないよう、ディレクトリ自体は
+	    # symlinkにせず、設定ファイルだけを実ディレクトリの中にlinkする ----
+	    if [[ "$name" == "herdr" && -d "$config_item" ]]; then
+		mkdir -p "$target"
+
+		for herdr_file in "$config_item"/*
+		do
+		    fname=$(basename "$herdr_file")
+		    # herdrが自分で生成するランタイムファイルはlinkしない
+		    case "$fname" in
+			session.json|*.log|*.sock) continue ;;
+		    esac
+		    ln -sfn "$herdr_file" "$target/$fname"
+		done
+
+		continue
+	    fi
+	    # -------------------------------------
+
 	    if [ -e "$target" ] || [ -L "$target" ]; then
 		read -p "$target already exists. overwrite? [Y/n] " answer
 		case $answer in


### PR DESCRIPTION
## Summary
- screenの操作感覚(escape=ctrl+z、ペイン分割 |/S)に合わせて .config/herdr/config.toml を追加
- ~/.config/herdr をリポジトリへ丸ごとsymlinkするとWSL2のDrvFsマウント上でUnixドメインソケットが作成できず起動に失敗する問題があったため、install.sh を herdr ディレクトリだけ実ディレクトリを維持しconfig.tomlのみlinkするよう修正
- herdrのランタイム生成物(session.json/ログ/ソケット)を.gitignoreで除外

## Test plan
- [x] WSL2上でinstall.shを再実行し、herdrが起動できることを確認
- [x] prefix+|, prefix+shift+s, prefix+shift+q の動作確認