### PR TITLE
miseの設定を追加する

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,6 @@
+# mise configuration
+# https://mise.jdx.dev/configuration.html
+
+[tasks.hello-mise]
+description = "Say hello"
+run = "echo hello pandineer"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .config/herdr/session.json
 .config/herdr/*.log
 .config/herdr/*.sock
+
+# mise local overrides (environment dependent settings)
+.config/mise/config.local.toml


### PR DESCRIPTION
## Summary
- .config/mise/config.toml を追加し、サンプルタスク hello-mise () を定義
- .gitignore に .config/mise/config.local.toml を追加し、ローカル用の上書き設定を無視するようにした

## Test plan
- [x] mise run hello-mise で "hello pandineer" が表示されることを確認