### PR TITLE
mise taskにherdr server stopを追加する

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -4,3 +4,7 @@
 [tasks.hello-mise]
 description = "Say hello"
 run = "echo hello pandineer"
+
+[tasks."herdr:server:stop"]
+description = "herdrのserverを停止する"
+run = "herdr server stop"


### PR DESCRIPTION
## Summary
- \`mise run herdr:server:stop\` で \`herdr server stop\` を実行できるタスクを追加

## Test plan
- [x] \`mise run herdr:server:stop\` を実行し、herdrのserverが停止することを確認